### PR TITLE
add README for check_available_memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A suite of Nagios style checks and metrics covering the basic needs for monitori
 
 ## List of Checks
 * CPU
-* Memory
+* [Memory](https://github.com/ncr-devops-platform/nagios-foundation/blob/master/cmd/check_available_memory/README.md)
 * Performance Counter
 * [Process](https://github.com/ncr-devops-platform/nagios-foundation/blob/master/cmd/check_process/README.md)
 * [Service](https://github.com/ncr-devops-platform/nagios-foundation/blob/master/cmd/check_service/README.md)

--- a/cmd/check_available_memory/README.md
+++ b/cmd/check_available_memory/README.md
@@ -1,0 +1,17 @@
+# Available Memory Check
+The available memory check (`check_available_memory`) checks the available memory as reported by the OS.
+
+## Intended Purpose
+The probable intended purpose of the available memory check is to query the OS for the amount of available memory, the amount of free memory, then calculate a memory used percentage. That memory used percentage is then compared against the `-warning` and `-critical` thresholds and an appropriate check result is output.
+
+### Flags
+* `-warning`: The percentage of used memory required to trigger a warning condition.
+* `-critical`: The percentage of used memory required to trigger a critical condition.
+* `-metric_name`: The name used in the nagios portion of the message output.
+
+## Implemented Purpose
+Someone looking through the code may notice what is currently implemented doesn't match what is probably the intended purpose. The details here are to help someone contributing to understand.
+
+The available memory check currently queries the OS for the amount of available memory (megabytes in Windows, kilobytes on Linux) and compares that against the `-warning` and `-critical` thresholds. These thresholds are `85` and `95` respectively. Because the amount of free memory available on an active OS is generally more than those thresholds, the check usually returns on OK status.
+
+For Linux, the check scrapes the `free` command and pulls the swap total instead of memory free.


### PR DESCRIPTION
`check_available_memory` seems to have a few opportunities available. The _implemented purpose_ is documented in the `README` along what what was probably the _intended purpose_.

This `README` should be reviewed and requirements taken from it before any changes are addressed.
