### PR TITLE
upgrade godel to 2.13.0

### DIFF
--- a/godel/config/godel.properties
+++ b/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.10.0/godel-2.10.0.tgz
-distributionSHA256=503074b9177d05152f3225a4bd8fa1516182f9c35d88796fbbdc975637e06c45
+distributionURL=https://palantir.bintray.com/releases/com/palantir/godel/godel/2.13.0/godel-2.13.0.tgz
+distributionSHA256=

--- a/godelw
+++ b/godelw
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.10.0
-DARWIN_CHECKSUM=2f2d8a62e598f8a7784c92a0e6325251efa347d3550187a290ab72a9ed44917c
-LINUX_CHECKSUM=36f963816d8e06ab6f41711fd66a75706d3ddb376de4edef80e4fd09688c97f5
+VERSION=2.13.0
+DARWIN_CHECKSUM=a2f5355729f43b6b174a2a26993b2067cef61af240f650def6359c3bad7ba91d
+LINUX_CHECKSUM=d7c147949f43f1930d013bac33af19e1d47aad8bed5fdb3cad0cceddd36d8ff4
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {


### PR DESCRIPTION
Resolves #83.

Note that if the repository was cloned previous to this commit, the end user must upgrade godel using the update command.
```
./godelw update
```

It'll be interested to see how/if this builds in Travis.
