### PR TITLE
Release to GitHub via Travis Deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,14 @@ install:
 script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && bash <(curl -s https://codecov.io/bash)
   - make package
+
+deploy:
+  provider: releases
+  api_key:
+    secure: BTtv1betWObLQiFJNKtIfaNtOSgkqqQvwYKwlGHRigRq7/+20F20xo/UKJJaMam7VmHM/+lHA+yYUDyX+YzUoURY5BxY+8QBs6FuqafoMZR5P2zsx2drFxumrqpFYrCpEQjSB+tCwyNQ+CdiuJBapRG/98ePco/VyIMgGNHa9swkxTvq0YFUheLIrBXvdeYWtew6p4FRQlcmUt9EtSOaKJ6x3mDhLa9MfLCo+0izE/dB0YrxJPCTIBQ0+eFvIU9Dw8mhCncwwfeRu6GPOeMVDA2htRwmlQt15V+a1oYlZfvp26Ga0jBljq0zAjMd/EEf9e4/Xk/Rdcl6BJ6863VVza44+8YeDNVanM4lKDrU9RTKVlVgk+r/BWKgH/EbWiTqDm7GE1hoZnfjp08TIQ0NAbLgIurOEPw6HICn4B5RpAuRtDKg+lvIi5aALgvZN2LSQ5h4vHITuebPGFtVRynd6iq2DkkwUYS/6PaGfBerMBJD/hH2ELiROcKh2p6Wyp6on8SIf+M+NouBnL9vJ6mr4Bw7ATz42H//3ITLdiC0uFY3iD0ObaGOVGX0P/j3AXK0bri8rnU8k5xT81awbX3/cjZK8hg++hRRKcWViQX7fXW8XxRtYvpnGGtMrZNITpR97aSL/qjPE2ERXqRkRPksJt8Qx7WwKzLBNYwdXZ7olrY=
+  file_glob: true
+  file: out/package/*.tgz
+  skip_cleanup: true
+  draft: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   api_key:
     secure: BTtv1betWObLQiFJNKtIfaNtOSgkqqQvwYKwlGHRigRq7/+20F20xo/UKJJaMam7VmHM/+lHA+yYUDyX+YzUoURY5BxY+8QBs6FuqafoMZR5P2zsx2drFxumrqpFYrCpEQjSB+tCwyNQ+CdiuJBapRG/98ePco/VyIMgGNHa9swkxTvq0YFUheLIrBXvdeYWtew6p4FRQlcmUt9EtSOaKJ6x3mDhLa9MfLCo+0izE/dB0YrxJPCTIBQ0+eFvIU9Dw8mhCncwwfeRu6GPOeMVDA2htRwmlQt15V+a1oYlZfvp26Ga0jBljq0zAjMd/EEf9e4/Xk/Rdcl6BJ6863VVza44+8YeDNVanM4lKDrU9RTKVlVgk+r/BWKgH/EbWiTqDm7GE1hoZnfjp08TIQ0NAbLgIurOEPw6HICn4B5RpAuRtDKg+lvIi5aALgvZN2LSQ5h4vHITuebPGFtVRynd6iq2DkkwUYS/6PaGfBerMBJD/hH2ELiROcKh2p6Wyp6on8SIf+M+NouBnL9vJ6mr4Bw7ATz42H//3ITLdiC0uFY3iD0ObaGOVGX0P/j3AXK0bri8rnU8k5xT81awbX3/cjZK8hg++hRRKcWViQX7fXW8XxRtYvpnGGtMrZNITpR97aSL/qjPE2ERXqRkRPksJt8Qx7WwKzLBNYwdXZ7olrY=
   file_glob: true
-  file: out/package/*.tgz
+  file: out/package/*
   skip_cleanup: true
   draft: true
   on:


### PR DESCRIPTION
Resolves #90 

The only changes required are to the `.travis.yml` file. Deploy is ran 1) after the tests and build are successful and 2) if the commit was tagged. Draft releases are created by default.

Note this requires a GitHub user (preferably a _machine user_) be created and a _Personal Access Token_ be created with the `public_repo` scope. This is done with `Settings > Developer settings > Personal access tokens`. Use `Generate new token`, give it a good description, then click the single `public_repo` box and finally the big green `Generate token` button. Take note of the generated token and copy it because it will never be seen again. The use of machine users is allowed by GitHub as seen at https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users

Next, the token must be encrypted using the public key Travis has already generated for the project. The ordained way is to use the Travis CLI, but that's a lot to install just to encrypt the token. An easy alternate method is to use the Bash script at https://github.com/dlenski/travis-encrypt-sh, generate the token, then paste it into the `.travis.yml` file at `deploy/api_key/secure`.

I have already created a GitHub machine user named `ncr-devops-machine` and a Personal Access Token with the proper permissions. I've also used this user to successfully test this configuration. The Personal Access Token has already been encrypted using the Travis public key for this project and the result is already in the `.travis.yml` file. If this user is used, just invite it as a Collaborator to this project. I can accept the invite and theoretically all this should just work. I do not have the permissions to invite a Collaborator to this project or team.

As stated in the original issue, the details start with the pages at:
https://docs.travis-ci.com/user/deployment/releases/
and
https://developer.github.com/v3/guides/managing-deploy-keys/