### PR TITLE
Use VERSION in build-args-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ install:
   - mv /home/travis/gopath/src/github.com/ncr-devops-platform/nagios-foundation /home/travis/gopath/src/github.com/ncr-devops-platform/nagiosfoundation
   - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - dep ensure -v
+  - git checkout .
+  - ./godelw version
+  - ./godelw project-version
 
 script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && bash <(curl -s https://codecov.io/bash)
   - make clean
-  - git checkout .
   - make package
 
 deploy:

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -5,7 +5,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_available_memory "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64
@@ -28,7 +28,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_cpu "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64
@@ -51,7 +51,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_performance_counter "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64
@@ -70,7 +70,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_service "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64
@@ -93,7 +93,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_user_group "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64
@@ -116,7 +116,7 @@ products:
       build-args-script: |
         echo "-ldflags"
         echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_process "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$(./godelw project-version)"
+        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
       os-archs:
         - os: windows
           arch: amd64


### PR DESCRIPTION
The contents of `build-args-script` are written to a temp file in the current directory which causes `./godelw project-version` to emit a `dirty` version.

Instead, use the environment variable `VERSION` which is set by godel before the script is called.

Don't use `version-var` as documented in the [Godel Build document](https://github.com/palantir/godel/blob/master/docs/Build.md) to set the version because that has the unfortunate side effect of disabling the `build-args-script`.