### PR TITLE
Improve and validate variable injection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
   - go test -race -coverprofile=coverage.txt -covermode=atomic -v ./... && bash <(curl -s https://codecov.io/bash)
   - make clean
   - make package
+  - scripts/validate-version.sh
 
 deploy:
   provider: releases

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -2,10 +2,7 @@ products:
   check_available_memory:
     build:
       main-pkg: 'cmd/check_available_memory'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_available_memory "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64
@@ -25,10 +22,7 @@ products:
   check_cpu:
     build:
       main-pkg: 'cmd/check_cpu'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_cpu "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64
@@ -48,10 +42,7 @@ products:
   check_performance_counter:
     build:
       main-pkg: 'cmd/check_performance_counter'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_performance_counter "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64
@@ -67,10 +58,7 @@ products:
   check_service:
     build:
       main-pkg: 'cmd/check_service'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_service "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64
@@ -90,10 +78,7 @@ products:
   check_user_group:
     build:
       main-pkg: 'cmd/check_user_group'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_user_group "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64
@@ -113,10 +98,7 @@ products:
   check_process:
     build:
       main-pkg: 'cmd/check_process'
-      build-args-script: |
-        echo "-ldflags"
-        echo -n "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdName=check_process "
-        echo "-X github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation.cmdVersion=$VERSION"
+      build-args-script: scripts/inject-name-version.sh
       os-archs:
         - os: windows
           arch: amd64

--- a/scripts/inject-name-version.sh
+++ b/scripts/inject-name-version.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PACKAGE="github.com/ncr-devops-platform/nagiosfoundation/cmd/initcmd"
+
+echo "-ldflags"
+echo -n "-X $PACKAGE.cmdName=$PRODUCT "
+echo "-X $PACKAGE.cmdVersion=$VERSION"
+

--- a/scripts/validate-version.sh
+++ b/scripts/validate-version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+tar zxf out/package/nagiosfoundation-linux-amd64-*.tgz
+CHECK_VERSION=$(./godelw project-version)
+EXIT=0
+
+for CHECK_NAME in $(ls bin); do
+    OUTPUT=$(bin/$CHECK_NAME version)
+
+    echo $OUTPUT
+
+    OUT_NAME=$(echo $OUTPUT | cut -d \  -f 1)
+    OUT_VERSION=$(echo $OUTPUT | cut -d \  -f 3)
+
+    if [ "$OUT_NAME" != "$CHECK_NAME" ]; then
+        echo "Check name is $CHECK_NAME but output name is $OUT_NAME"
+        EXIT=1
+    elif [ "$OUT_VERSION" != "$CHECK_VERSION" ]; then
+        echo "Version is $CHECK_VERSION but output version is $OUT_VERSION"
+        EXIT=1
+    fi
+done
+
+exit $EXIT


### PR DESCRIPTION
Resolves #135 

With this bug, it's time to revisit how the version is injected at build time in an attempt to prevent this from happening again.

### Inject in a Centralized Script
The script bits have been moved out of `godel/config/dist-plugin.yml` and placed into a new `scripts/` directory at `scripts/inject-name-version.sh`. Now when changes are made, they can be made one time, in one location, rather than scattering changes around `dist-plugin.yml`. The script also uses godel environment variables for the injections.

### Testing in Travis Builds
Testing is now done in the Travis build to validate the information injected is also output when the `version` argument is used. This is done with `scripts/validate-version.sh` that  will exit with `1` if the validation fails which in turn will cause the Travis build to fail and thus the PR to be rejected.