### PR TITLE
Initial implementation of a check_http plugin

### DIFF
--- a/cmd/check_http/cmd/root.go
+++ b/cmd/check_http/cmd/root.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ncr-devops-platform/nagiosfoundation/cmd/initcmd"
+	"github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation"
+	"github.com/spf13/cobra"
+)
+
+// Execute runs the root command
+func Execute() {
+	var url string
+	var redirect bool
+	var timeout int
+
+	var rootCmd = &cobra.Command{
+		Use:   "check_http",
+		Short: "Check the response code of an http request.",
+		Long:  `Perform an HTTP get request and assert whether it is OK, warning or critical.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.ParseFlags(os.Args)
+			msg, retval := nagiosfoundation.CheckHTTP(url, redirect, timeout)
+
+			fmt.Println(msg)
+			os.Exit(retval)
+		},
+	}
+
+	initcmd.AddVersionCommand(rootCmd)
+
+	rootCmd.Flags().StringVarP(&url, "url", "u", "http://127.0.0.1", "the URL to check")
+	rootCmd.Flags().BoolVarP(&redirect, "redirect", "r", false, "follow redirects?")
+	rootCmd.Flags().IntVarP(&timeout, "timeout", "t", 15, "timeout in seconds")
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/check_http/main.go
+++ b/cmd/check_http/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/ncr-devops-platform/nagiosfoundation/cmd/check_http/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -115,3 +115,23 @@ products:
             os-archs:
               - os: windows
                 arch: amd64
+  check_http:
+    build:
+      main-pkg: 'cmd/check_http'
+      build-args-script: scripts/inject-name-version.sh
+      os-archs:
+        - os: windows
+          arch: amd64
+        - os: windows
+          arch: "386"
+        - os: linux
+          arch: amd64
+        - os: linux
+          arch: "386"
+    dist:
+        disters:
+          type: os-arch-bin
+          config:
+            os-archs:
+              - os: windows
+                arch: amd64

--- a/lib/app/nagiosfoundation/check_http.go
+++ b/lib/app/nagiosfoundation/check_http.go
@@ -1,0 +1,63 @@
+package nagiosfoundation
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// CheckHTTP attempts an HTTP request against the provided url, reporting the HTTP response code and overall request state.
+func CheckHTTP(url string, redirect bool, timeout int) (string, int) {
+
+	var msg string
+	var retCode int
+	var responseStateText string
+	var responseCode string
+
+	status, err := statusCode(url, timeout)
+	if err != nil {
+		retCode = 2
+		responseStateText = "CRITICAL"
+		responseCode = "UNHANDLED ERROR"
+	}
+
+	switch {
+	case status >= 400:
+		retCode = 2
+		responseStateText = "CRITICAL"
+		responseCode = strconv.Itoa(status)
+	case status >= 300 && redirect:
+		retCode = 0
+		responseStateText = "OK"
+		responseCode = strconv.Itoa(status)
+	case status >= 300:
+		retCode = 1
+		responseStateText = "WARNING"
+		responseCode = strconv.Itoa(status)
+	default:
+		retCode = 0
+		responseStateText = "OK"
+		responseCode = strconv.Itoa(status)
+	}
+
+	msg = fmt.Sprintf("CheckHttp %s - Url %s responded with %s", responseStateText, url, responseCode)
+
+	return msg, retCode
+}
+
+func statusCode(url string, timeout int) (int, error) {
+	http.DefaultClient.Timeout = time.Duration(timeout) * time.Second
+
+	request, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	response, err := http.DefaultTransport.RoundTrip(request)
+	if err != nil {
+		return 0, err
+	}
+
+	return response.StatusCode, nil
+}

--- a/lib/app/nagiosfoundation/check_http.go
+++ b/lib/app/nagiosfoundation/check_http.go
@@ -35,6 +35,10 @@ func CheckHTTP(url string, redirect bool, timeout int) (string, int) {
 		retCode = 1
 		responseStateText = "WARNING"
 		responseCode = strconv.Itoa(status)
+	case status == -1:
+		retCode = 2
+		responseStateText = "UNKNOWN ERROR"
+		responseCode = strconv.Itoa(status)
 	default:
 		retCode = 0
 		responseStateText = "OK"
@@ -51,12 +55,12 @@ func statusCode(url string, timeout int) (int, error) {
 
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	response, err := http.DefaultTransport.RoundTrip(request)
 	if err != nil {
-		return 0, err
+		return -1, err
 	}
 
 	return response.StatusCode, nil


### PR DESCRIPTION
```
$ ./check_http --help
Perform an HTTP get request and assert whether it is OK, warning or critical.

Usage:
  check_http [flags]
  check_http [command]

Available Commands:
  help        Help about any command
  version     Print the version

Flags:
  -h, --help          help for check_http
  -r, --redirect      follow redirects?
  -t, --timeout int   timeout in seconds (default 15)
  -u, --url string    the URL to check (default "http://127.0.0.1")

Use "check_http [command] --help" for more information about a command.
```