### PR TITLE
Add tests for check_file_exists

### DIFF
--- a/cmd/check_file_exists/cmd/root.go
+++ b/cmd/check_file_exists/cmd/root.go
@@ -5,12 +5,12 @@ import (
 	"os"
 
 	"github.com/ncr-devops-platform/nagiosfoundation/cmd/initcmd"
-	"github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation"
 	"github.com/spf13/cobra"
 )
 
 // Execute runs the root command
-func Execute() {
+func Execute(apiCheckFileExists func(string, bool) (string, int)) int {
+	var exitCode int
 	var pattern string
 	var negate bool
 
@@ -19,20 +19,22 @@ func Execute() {
 		Short: "Check for the existence of one or more files matching specific filepath or globbing patterns.",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.ParseFlags(os.Args)
-			msg, retval := nagiosfoundation.CheckFileExists(pattern, negate)
+			msg, retval := apiCheckFileExists(pattern, negate)
 
 			fmt.Println(msg)
-			os.Exit(retval)
+			exitCode = retval
 		},
 	}
 
 	initcmd.AddVersionCommand(rootCmd)
 
 	rootCmd.Flags().StringVarP(&pattern, "pattern", "p", "", "Filepath or globbing pattern to check for one or more existing files")
-	rootCmd.Flags().BoolVarP(&negate, "negate", "n", false, "If set, asserts filepath or globbing pattern should not match any existing file")
+	rootCmd.Flags().BoolVarP(&negate, "negate", "n", false, "Asserts filepath or globbing pattern should NOT match any existing file")
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		fmt.Fprintln(os.Stdout, err)
+		exitCode = 1
 	}
+
+	return exitCode
 }

--- a/cmd/check_file_exists/cmd/root_test.go
+++ b/cmd/check_file_exists/cmd/root_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCheckFileExistsCmd(t *testing.T) {
+	type testItem struct {
+		description string
+		arguments   []string
+		exitCode    int
+	}
+
+	var expectedExitCode int
+
+	testList := []testItem{
+		{
+			description: "Invalid commmand",
+			arguments:   []string{"check_file_exists", "invalidcommand"},
+			exitCode:    1,
+		},
+		{
+			description: "Valid command, exit code 0",
+			arguments:   []string{"check_file_exists"},
+			exitCode:    0,
+		},
+		{
+			description: "Valid command, exit code 2",
+			arguments:   []string{"check_file_exists"},
+			exitCode:    2,
+		},
+	}
+
+	apiCheckFileExists := func(pattern string, negate bool) (string, int) {
+		return "Test Message", expectedExitCode
+	}
+
+	savedArgs := os.Args
+
+	for _, i := range testList {
+		os.Args = i.arguments
+		expectedExitCode = i.exitCode
+		actualExitCode := Execute(apiCheckFileExists)
+		if actualExitCode != i.exitCode {
+			t.Errorf("%s: Expected Code: %d, Actual Code: %d", i.description, i.exitCode, actualExitCode)
+		}
+	}
+
+	os.Args = savedArgs
+}

--- a/cmd/check_file_exists/main.go
+++ b/cmd/check_file_exists/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"os"
+
 	"github.com/ncr-devops-platform/nagiosfoundation/cmd/check_file_exists/cmd"
+	"github.com/ncr-devops-platform/nagiosfoundation/lib/app/nagiosfoundation"
 )
 
 func main() {
-	cmd.Execute()
+	os.Exit(cmd.Execute(nagiosfoundation.CheckFileExists))
 }

--- a/lib/app/nagiosfoundation/check_file_exists_test.go
+++ b/lib/app/nagiosfoundation/check_file_exists_test.go
@@ -1,0 +1,88 @@
+package nagiosfoundation
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func validateTestCheckFileExistsResponse(t *testing.T, description string, expectedCode int, expectedMsg string, actualCode int, actualMsg string) {
+	t.Helper()
+
+	if expectedCode != actualCode {
+		t.Errorf("%s: Expected Code: %d, Actual Code: %d", description, expectedCode, actualCode)
+	}
+
+	if strings.Contains(actualMsg, expectedMsg) == false {
+		t.Errorf("%s: Expected Message: %s, Actual Message: %s", description, expectedMsg, actualMsg)
+	}
+}
+
+func TestCheckFileExists(t *testing.T) {
+	var msg string
+	var code int
+	const validTestFile = "validtestfile"
+	const invalidTestFile = "invalidtestfile"
+	const ok = "OK:"
+	const critical = "CRITICAL:"
+	const unknown = "UNKNOWN:"
+
+	type testItem struct {
+		description  string
+		file         string
+		inverted     bool
+		expectedCode int
+		expectedMsg  string
+	}
+
+	testList := []testItem{
+		{
+			description:  "Invalid Glob Pattern",
+			file:         "[]a",
+			inverted:     false,
+			expectedCode: 3,
+			expectedMsg:  unknown,
+		},
+		{
+			description:  "File does not exist, not inverted",
+			file:         invalidTestFile,
+			inverted:     false,
+			expectedCode: 2,
+			expectedMsg:  critical,
+		},
+		{
+			description:  "File does not exist, inverted",
+			file:         invalidTestFile,
+			inverted:     true,
+			expectedCode: 0,
+			expectedMsg:  ok,
+		},
+		{
+			description:  "File exists, not inverted",
+			file:         validTestFile,
+			inverted:     false,
+			expectedCode: 0,
+			expectedMsg:  ok,
+		},
+		{
+			description:  "File exists, inverted",
+			file:         validTestFile,
+			inverted:     true,
+			expectedCode: 2,
+			expectedMsg:  critical,
+		},
+	}
+
+	// Create a valid file
+	if fp, err := os.OpenFile(validTestFile, os.O_RDONLY|os.O_CREATE, 0666); err != nil {
+		t.Errorf("Error creating test file: %s. Error: %s", validTestFile, err)
+	} else {
+		defer os.Remove(validTestFile)
+		fp.Close()
+	}
+
+	for _, i := range testList {
+		msg, code = CheckFileExists(i.file, i.inverted)
+		validateTestCheckFileExistsResponse(t, i.description, i.expectedCode, i.expectedMsg, code, msg)
+	}
+}


### PR DESCRIPTION
Added tests for `CheckFileExists()` in the nagiosfoundation API and `check_file_exists` CLI command. In the course of this, performed some refactoring of `CheckFileExists()` then refactored and added DI to CLI's `Execute()` function. Also made the result message more consistent.