### PR TITLE
Increase test coverage for check_http

### DIFF
--- a/lib/app/nagiosfoundation/check_http.go
+++ b/lib/app/nagiosfoundation/check_http.go
@@ -80,13 +80,15 @@ func statusCode(url string, timeout int, accept string) (int, string, error) {
 	if !isURL(url) {
 		return -1, "", fmt.Errorf("%s is not a valid url", url)
 	}
+
 	http.DefaultClient.Timeout = time.Duration(timeout) * time.Second
 
 	request, err := http.NewRequest("GET", url, nil)
-	request.Header.Set("accept", accept)
 	if err != nil {
 		return 0, "", err
 	}
+
+	request.Header.Set("accept", accept)
 
 	response, err := http.DefaultTransport.RoundTrip(request)
 	if err != nil {

--- a/lib/app/nagiosfoundation/check_http_test.go
+++ b/lib/app/nagiosfoundation/check_http_test.go
@@ -1,7 +1,6 @@
 package nagiosfoundation
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,64 +8,74 @@ import (
 
 func TestCheckHTTP(t *testing.T) {
 	var httpStatus int
+	var responseBody string
 
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(httpStatus)
+		w.Write([]byte(responseBody))
 	}))
 	defer httpServer.Close()
 	var format = ""
 	var path = ""
 	var expectedValue = ""
+
 	// Code 200
 	httpStatus = http.StatusOK
-	msg, code := CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code := CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
 	if code != 0 {
 		t.Error("CheckHTTP() should return code of 0 when on OK (200) response")
 	}
 
 	// Code 400
 	httpStatus = http.StatusBadRequest
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when on bad request (400) response")
 	}
 
 	// Code 300
 	httpStatus = http.StatusMultipleChoices
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
 	if code != 1 {
 		t.Error("CheckHTTP() should return code of 2 when on multiple choices (300) response")
 	}
 
 	// Code 300 with redirect on
 	httpStatus = http.StatusMultipleChoices
-	msg, code = CheckHTTP(httpServer.URL, true, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, true, 1, format, path, expectedValue)
+	if code != 0 {
+		t.Error("CheckHTTP() should return code of 0 when on multiple choices (300) with redirect response")
+	}
+
+	// Code 200 with format json and a match
+	httpStatus = http.StatusOK
+	responseBody = `{"id":"HeaFdiyIJe","joke":"What kind of magic do cows believe in? MOODOO.","status":200}`
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "HeaFdiyIJe")
+	if code != 0 {
+		t.Error("CheckHTTP() should return code of 0 when json path matches expected value")
+	}
+
+	// Code 200 with format json and failed match
+	httpStatus = http.StatusOK
+	responseBody = `{"id":"HeaFdiyIJe","joke":"What kind of magic do cows believe in? MOODOO.","status":200}`
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "failmatch")
+	if code != 2 {
+		t.Error("CheckHTTP() should return code of 2 when json path matches expected value")
+	}
 
 	// Shut down test server to generate errors
 	httpServer.Close()
 
 	// No server for connection
 	httpStatus = http.StatusOK
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when no server is available")
 	}
 
 	// Invalid URL
 	httpStatus = http.StatusOK
-	msg, code = CheckHTTP("invalid%url", false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP("invalid%url", false, 1, format, path, expectedValue)
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when given an unparseable URL")
 	}


### PR DESCRIPTION
This PR will increase the coverage for check_http.

I've also made a minor modification to `statusCode()`. I've moved the call to `request.Header.Set()` to after the error check for `http.NewRequest()`. I suspect the whole reason the `isURL()` helper function was created was because the unit tests were breaking after the json modifications were added because `http.NewRequest()` in the unit tests would sometimes give an error, resulting in an invalid `request` variable which then caused `request.Header.Set()` to fail. Creating and adding `isURL()` prevented this. If this is the reason `isURL()` was created and added we should consider removing it because the call to `http.NewRequest()` already calls `url.Parse()` to validate the URL, so this is now being done twice.

I've also removed all the `fmt.Println()` calls from the unit tests. They are not needed.

The unit tests don't cover the error returns from `RoundTrip()` and `ReadAll()`. Those would require a lot of DI for coverage that's probably not worth the effort.