### PR TITLE
enable use of operators for check_http json field

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:e3983013d82da8c49fb6776c6317d0da4b9cb926f1bb11af37f8c975889db042"
+  name = "github.com/PaesslerAG/gval"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0ce847fc5e6163ee05ae770a441ba497fc77dcaa"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
@@ -73,6 +81,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/PaesslerAG/gval",
     "github.com/StackExchange/wmi",
     "github.com/pbnjay/memory",
     "github.com/spf13/cobra",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,3 +52,7 @@
 [[constraint]]
   name = "github.com/thedevsaddam/gojsonq"
   version = "2.2.2"
+
+[[constraint]]
+  name = "github.com/PaesslerAG/gval"
+  version = "1.0.1"

--- a/cmd/check_http/cmd/root.go
+++ b/cmd/check_http/cmd/root.go
@@ -9,21 +9,18 @@ import (
 )
 
 // Execute runs the root command
-func Execute(apiCheckHTTP func(string, bool, int, string, string, string) (string, int)) int {
-	var exitCode int
-	var url string
+func Execute(apiCheckHTTP func(string, bool, int, string, string, string, string) (string, int)) int {
 	var redirect bool
-	var timeout int
-	var format string
-	var path string
-	var expectedValue string
+	var exitCode, timeout int
+	var url, format, path, expectedValue, expression string
+
 	var rootCmd = &cobra.Command{
 		Use:   "check_http",
 		Short: "Check the response code of an http request.",
 		Long:  `Perform an HTTP get request and assert whether it is OK, warning or critical.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.ParseFlags(os.Args)
-			msg, retval := apiCheckHTTP(url, redirect, timeout, format, path, expectedValue)
+			msg, retval := apiCheckHTTP(url, redirect, timeout, format, path, expectedValue, expression)
 
 			fmt.Println(msg)
 			exitCode = retval
@@ -38,6 +35,7 @@ func Execute(apiCheckHTTP func(string, bool, int, string, string, string) (strin
 	rootCmd.Flags().StringVarP(&format, "format", "f", "", "The expected response format: json")
 	rootCmd.Flags().StringVarP(&path, "path", "p", "", "The path in the return value data to test against the expected value")
 	rootCmd.Flags().StringVarP(&expectedValue, "expectedValue", "e", "", "The expected response data value")
+	rootCmd.Flags().StringVarP(&expression, "expression", "", "", "Expression to evaluate against response data value")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stdout, err)

--- a/lib/app/nagiosfoundation/check_http.go
+++ b/lib/app/nagiosfoundation/check_http.go
@@ -1,106 +1,172 @@
 package nagiosfoundation
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
+	"github.com/PaesslerAG/gval"
 	"github.com/thedevsaddam/gojsonq"
 )
 
-// CheckHTTP attempts an HTTP request against the provided url, reporting the HTTP response code and overall request state.
-func CheckHTTP(url string, redirect bool, timeout int, format string, path string, expectedValue string) (string, int) {
+func getAcceptText(format string) (string, error) {
 	var accept string
-	var msg string
-	var retCode int
-	var responseStateText string
-	var responseCode string
+	var err error
 
-	switch {
-	case format == "json":
+	switch format {
+	case "json":
 		accept = "application/json"
+	case "":
+		accept = ""
 	default:
 		accept = ""
+		err = errors.New("Invalid accept type")
 	}
 
-	status, body, _ := statusCode(url, timeout, accept)
+	return accept, err
+}
+
+func evaluateStatusCode(status int, redirect bool) (int, string) {
+	var retCode int
+	var responseStateText string
 
 	switch {
-	case status >= 400:
+	case status >= http.StatusBadRequest:
 		retCode = 2
 		responseStateText = "CRITICAL"
-		responseCode = strconv.Itoa(status)
-	case status >= 300 && redirect:
+	case status >= http.StatusMultipleChoices && redirect:
 		retCode = 0
 		responseStateText = "OK"
-		responseCode = strconv.Itoa(status)
-	case status >= 300:
+	case status >= http.StatusMultipleChoices:
 		retCode = 1
 		responseStateText = "WARNING"
-		responseCode = strconv.Itoa(status)
 	case status == -1:
 		retCode = 2
 		responseStateText = "UNKNOWN ERROR"
-		responseCode = strconv.Itoa(status)
 	default:
 		retCode = 0
 		responseStateText = "OK"
-		responseCode = strconv.Itoa(status)
 	}
 
+	return retCode, responseStateText
+}
+
+func evaluateExpectedValue(actualValue, expectedValue, path string) (int, string, string) {
+	var retCode int
+	var responseStateText, checkMsg string
+
+	if actualValue == expectedValue {
+		retCode = 0
+		responseStateText = "OK"
+		checkMsg = fmt.Sprintf(". The value found at %s has expected value %s", path, expectedValue)
+	} else {
+		retCode = 2
+		responseStateText = "CRITICAL"
+		checkMsg = fmt.Sprintf(". The value found at %s has unexpected value %s", path, actualValue)
+	}
+
+	return retCode, responseStateText, checkMsg
+}
+
+func evaluateExpression(actualValue interface{}, expression, path string) (int, string, string) {
+	var retCode int
+	var responseStateText, checkMsg string
+
+	evalResult, err := gval.Evaluate("value "+expression, map[string]interface{}{"value": actualValue})
+	if err == nil {
+		if evalResult == true {
+			retCode = 0
+			responseStateText = "OK"
+			checkMsg = fmt.Sprintf(". The value found at %s with value %v and expression \"%s\" yields true", path, actualValue, expression)
+		} else {
+			retCode = 2
+			responseStateText = "CRITICAL"
+			checkMsg = fmt.Sprintf(". The value found at %s with value %v does not match expression \"%s\"", path, actualValue, expression)
+		}
+	} else {
+		retCode = 2
+		responseStateText = "CRITICAL"
+		checkMsg = fmt.Sprintf(". Error processing value found at %s with value %v using expression \"%s\": %s", path, actualValue, expression, err)
+	}
+
+	return retCode, responseStateText, checkMsg
+}
+
+// CheckHTTP attempts an HTTP request against the provided url, reporting the HTTP response code and overall request state.
+func CheckHTTP(url string, redirect bool, timeout int, format, path, expectedValue, expression string) (string, int) {
+	var retCode int
+	var msg string
+
+	acceptText, err := getAcceptText(format)
+	if err != nil {
+		return fmt.Sprintf("CheckHttp CRITICAL - The format (--format) \"%s\" is not valid. The only valid value is \"json\".", format),
+			2
+	}
+
+	status, body, _ := statusCode(url, timeout, acceptText)
+
+	retCode, responseStateText := evaluateStatusCode(status, redirect)
+	responseCode := strconv.Itoa(status)
+
 	var checkMsg = ""
-	if retCode == 0 &&
-		len(expectedValue) > 0 &&
-		len(format) > 0 &&
-		len(path) > 0 {
+	if retCode == 0 && len(format) > 0 && len(path) > 0 {
+		var queryValue string
 
 		switch {
 		case format == "json":
-			queryValue := fmt.Sprintf("%v", gojsonq.New().JSONString(body).Find(path))
-			if queryValue == expectedValue {
-				checkMsg = fmt.Sprintf(". The value found at %s has expected value %s", path, expectedValue)
+			expectedValueLen := len(expectedValue)
+			expressionLen := len(expression)
+
+			value := gojsonq.New().JSONString(body).Find(path)
+
+			if value == nil {
+				retCode = 2
+				responseStateText = "CRITICAL"
+				checkMsg = fmt.Sprintf(". No entry at path %s", path)
+			} else if expectedValueLen > 0 && expressionLen > 0 {
+				retCode = 2
+				responseStateText = "CRITICAL"
+				checkMsg = fmt.Sprintf(". Both --expectedValue and --expression given but only one is used")
+			} else if expectedValueLen > 0 {
+				queryValue = fmt.Sprintf("%v", value)
+				retCode, responseStateText, checkMsg = evaluateExpectedValue(queryValue, expectedValue, path)
+			} else if expressionLen > 0 {
+				retCode, responseStateText, checkMsg = evaluateExpression(value, expression, path)
 			} else {
 				retCode = 2
 				responseStateText = "CRITICAL"
-				checkMsg = fmt.Sprintf(". The value found at %s has unexpected value %s", path, queryValue)
+				checkMsg = fmt.Sprintf(". --expectedValue or --expression not given")
 			}
 		}
 	}
 
 	msg = fmt.Sprintf("CheckHttp %s - Url %s responded with %s%s", responseStateText, url, responseCode, checkMsg)
-	strconv.Itoa(status)
 
 	return msg, retCode
 }
 
 func statusCode(url string, timeout int, accept string) (int, string, error) {
-	if !isURL(url) {
-		return -1, "", fmt.Errorf("%s is not a valid url", url)
-	}
 	http.DefaultClient.Timeout = time.Duration(timeout) * time.Second
 
 	request, err := http.NewRequest("GET", url, nil)
-	request.Header.Set("accept", accept)
 	if err != nil {
-		return 0, "", err
+		return -1, "", err
 	}
+
+	request.Header.Set("accept", accept)
 
 	response, err := http.DefaultTransport.RoundTrip(request)
 	if err != nil {
 		return -1, "", err
 	}
+	defer response.Body.Close()
 
 	body, readErr := ioutil.ReadAll(response.Body)
 	if readErr != nil {
 		return -1, "", readErr
 	}
 	return response.StatusCode, string(body), nil
-}
-
-func isURL(str string) bool {
-	u, err := url.Parse(str)
-	return err == nil && u.Scheme != "" && u.Host != ""
 }

--- a/lib/app/nagiosfoundation/check_http_test.go
+++ b/lib/app/nagiosfoundation/check_http_test.go
@@ -1,73 +1,297 @@
 package nagiosfoundation
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
 func TestCheckHTTP(t *testing.T) {
 	var httpStatus int
+	idValue := 1337
+	idValueString := strconv.Itoa(idValue)
 
+	responseBody := `{"id":"` + idValueString + `"}`
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(httpStatus)
+		w.Write([]byte(responseBody))
 	}))
 	defer httpServer.Close()
 	var format = ""
 	var path = ""
 	var expectedValue = ""
+
 	// Code 200
 	httpStatus = http.StatusOK
-	msg, code := CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code := CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
 	if code != 0 {
 		t.Error("CheckHTTP() should return code of 0 when on OK (200) response")
 	}
 
 	// Code 400
 	httpStatus = http.StatusBadRequest
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when on bad request (400) response")
 	}
 
 	// Code 300
 	httpStatus = http.StatusMultipleChoices
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
 	if code != 1 {
 		t.Error("CheckHTTP() should return code of 2 when on multiple choices (300) response")
 	}
 
 	// Code 300 with redirect on
 	httpStatus = http.StatusMultipleChoices
-	msg, code = CheckHTTP(httpServer.URL, true, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, true, 1, format, path, expectedValue, "")
+	if code != 0 {
+		t.Error("CheckHTTP() should return code of 0 when on multiple choices (300) with redirect response")
+	}
+
+	// Code 200 with format json and a match on expected value
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", idValueString, "")
+	if code != 0 {
+		t.Error("CheckHTTP() should return code of 0 when json path matches expected value")
+	}
+
+	// Code 200 with format json and failed match on expected value
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "failmatch", "")
+	if code != 2 {
+		t.Error("CheckHTTP() should return code of 2 when json path does not match expected value")
+	}
+
+	// Code 200 with format json and expression true
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "!= \""+idValueString+"\"")
+	if code != 2 {
+		t.Error("CheckHTTP() should return code of 2 when json path causes expression to return false")
+	}
+
+	// Code 200 with format json and no expected value or expression
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "")
+	if code != 2 {
+		t.Error("CheckHTTP() should return code of 2 with json path but no expected value or expression")
+	}
+
+	// Code 200 with format json and but both expected value and expression given
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "expectedvalue", "expression")
+	if code != 2 {
+		t.Error("CheckHTTP() should return code of 2 with json path but no expected value or expression")
+	}
+
+	// Code 200 with format json and expression true using integer
+	responseBody = `{"id":` + idValueString + `}`
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "id", "", "== "+idValueString)
+	if code != 0 {
+		t.Errorf("CheckHTTP() should return code of 0 with json path but and comparison to int %d", idValue)
+	}
+
+	// Invalid format
+	responseBody = `{"id":` + idValueString + `}`
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "invalidformat", "id", "", "== "+idValueString)
+	if code != 2 {
+		t.Errorf("CheckHTTP() should return code of 2 when given an invalid format")
+	}
+
+	// Invalid path
+	responseBody = `{"id":` + idValueString + `}`
+	httpStatus = http.StatusOK
+	_, code = CheckHTTP(httpServer.URL, false, 1, "json", "invalidpath", "", "== "+idValueString)
+	if code != 2 {
+		t.Errorf("CheckHTTP() should return code of 2 when given an invalid path")
+	}
 
 	// Shut down test server to generate errors
 	httpServer.Close()
 
 	// No server for connection
 	httpStatus = http.StatusOK
-	msg, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP(httpServer.URL, false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when no server is available")
 	}
 
 	// Invalid URL
 	httpStatus = http.StatusOK
-	msg, code = CheckHTTP("invalid%url", false, 1, format, path, expectedValue)
-	fmt.Println(msg)
-	fmt.Println(code)
+	_, code = CheckHTTP("invalid%url", false, 1, format, path, expectedValue, "")
 	if code != 2 {
 		t.Error("CheckHTTP() should return code of 2 when given an unparseable URL")
+	}
+}
+
+func TestAcceptText(t *testing.T) {
+	// Format is an empty string
+	expectedValue := ""
+	actualValue, err := getAcceptText("")
+	if actualValue != expectedValue {
+		t.Errorf("getAcceptText() should return empty string on empty format but returned \"%s\"", actualValue)
+	}
+
+	// Format is an invalid format
+	actualValue, err = getAcceptText("invalidformat")
+	if err == nil {
+		t.Errorf("getAcceptText() should return error on invalid format")
+	}
+
+	if actualValue != expectedValue {
+		t.Errorf("getAcceptText() should return empty string on invalid format but returned \"%s\"", actualValue)
+	}
+
+	// Format is json
+	expectedValue = "application/json"
+	actualValue, err = getAcceptText("json")
+	if actualValue != expectedValue {
+		t.Errorf("getAcceptText() should return \"%s\" on json format but returned \"%s\"", expectedValue, actualValue)
+	}
+}
+
+func TestEvaluateStatusCode(t *testing.T) {
+	// http.StatusBadRequest
+	expectedCode := 2
+	expectedText := "CRITICAL"
+	actualCode, actualText := evaluateStatusCode(http.StatusBadRequest, false)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateStatusCode() with http.StatusBadRequest expected code of %d but returned %d", expectedCode, actualCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateStatusCode() with http.StatusBadRequest expected text of %s but returned %s", expectedText, actualText)
+	}
+
+	// http.StatusMultipleChoices with redirect false
+	expectedCode = 1
+	expectedText = "WARNING"
+	actualCode, actualText = evaluateStatusCode(http.StatusMultipleChoices, false)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateStatusCode() with http.StatusMultipleChoices and redirect false expected code of %d but returned %d", expectedCode, actualCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateStatusCode() with http.StatusMultipleChoices and redirect false expected text of %s but returned %s", expectedText, actualText)
+	}
+
+	// http.StatusMultipleChoices with redirect true
+	expectedCode = 0
+	expectedText = "OK"
+	actualCode, actualText = evaluateStatusCode(http.StatusMultipleChoices, true)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateStatusCode() with http.StatusMultipleChoices and redirect true expected code of %d but returned %d", expectedCode, actualCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateStatusCode() with http.StatusMultipleChoices and redirect true expected text of %s but returned %s", expectedText, actualText)
+	}
+
+	// http.StatusOK
+	expectedCode = 0
+	expectedText = "OK"
+	actualCode, actualText = evaluateStatusCode(http.StatusOK, false)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateStatusCode() with http.StatusOK expected code of %d but returned %d", expectedCode, actualCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateStatusCode() with http.StatusOK expected text of %s but returned %s", expectedText, actualText)
+	}
+
+	// Unknown (-1)
+	expectedCode = 2
+	expectedText = "UNKNOWN ERROR"
+	actualCode, actualText = evaluateStatusCode(-1, false)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateStatusCode() with -1 expected code of %d but returned %d", expectedCode, actualCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateStatusCode() with -1 expected text of %s but returned %s", expectedText, actualText)
+	}
+}
+
+func TestEvaluateExpectedValue(t *testing.T) {
+	actualValue := "testvalue"
+	expectedGoodValue := actualValue
+	expectedBadValue := "nomatch"
+	testPath := "testpath"
+
+	expectedCode := 0
+	expectedText := "OK"
+	actualCode, actualText, _ := evaluateExpectedValue(actualValue, expectedGoodValue, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpectedValue() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpectedValue() returned actual text of %s when expecting %s", actualText, expectedText)
+	}
+
+	expectedCode = 2
+	expectedText = "CRITICAL"
+	actualCode, actualText, _ = evaluateExpectedValue(actualValue, expectedBadValue, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpectedValue() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpectedValue() returned actual text of %s when expecting %s", actualText, expectedText)
+	}
+}
+
+func TestEvaluateExpression(t *testing.T) {
+	actualValue := "testvalue"
+	trueExpression := "== \"" + actualValue + "\""
+	falseExpression := "!= \"" + actualValue + "\""
+	errorExpression := "+- \"" + actualValue + "\""
+	testPath := "testpath"
+
+	expectedCode := 0
+	expectedText := "OK"
+	actualCode, actualText, _ := evaluateExpression(actualValue, trueExpression, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpression() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpression() returned actual text of %s when expecting %s", actualText, expectedText)
+	}
+
+	expectedCode = 2
+	expectedText = "CRITICAL"
+	actualCode, actualText, _ = evaluateExpression(actualValue, falseExpression, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpression() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpression() returned actual text of %s when expecting %s", actualText, expectedText)
+	}
+
+	expectedCode = 2
+	expectedText = "CRITICAL"
+	actualCode, actualText, _ = evaluateExpression(actualValue, falseExpression, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpression() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpression() returned actual text of %s when expecting %s", actualText, expectedText)
+	}
+
+	expectedCode = 2
+	expectedText = "CRITICAL"
+	actualCode, actualText, _ = evaluateExpression(actualValue, errorExpression, testPath)
+	if actualCode != expectedCode {
+		t.Errorf("evaluateExpression() returned actual code of %d when expecting %d", actualCode, expectedCode)
+	}
+
+	if actualText != expectedText {
+		t.Errorf("evaluateExpression() returned actual text of %s when expecting %s", actualText, expectedText)
 	}
 }


### PR DESCRIPTION
The PR addresses the enhancement requested in issue #155, which is to add the ability to make comparisons other than string equality to a json field. This enhancement is much more complex than appears on the surface. I've taken some liberties in expanding this request to make it more flexible.

This PR implements the [Gval expression evaluation package](https://github.com/PaesslerAG/gval) to compare against a json field. Using a package means not coding all the expressions that may be asked for in the future (a complex task). Using this package gives the ability to use `==`, `!=`, `>`, `<`, `>=`, `<=` and probably more. The code uses an `interface{}` for the value, meaning these comparisons will work for not only strings, but also numbers. The comparison made depends on the use of double-quotes after the comparison operand.

Some examples. `== "comparetothistring"` gives a string comparison while `== 1337` gives a number comparison. Note the use of these quotes is important because `"1337" < "500"` (string comparison) will yield `true` while `1337 < 500` (number comparison) will yield `false`.

This new feature is enabled with the use of the `--expression` option. While the "old" `--expectedValue` option will continue to work for equality string comparison, you should consider using `--expression` for any future tasks.

Using the URL from [Release 0.1.3](https://github.com/ncr-devops-platform/nagios-foundation/releases/tag/0.1.3) (Http parsing check), here's some examples of how to use this `--expression` option.

For starters, here's how the `--expectedValue` and `--expression` options can be equally used.

```
check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe --format json --path id --expectedValue HeaFdiyIJe

check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe --format json --path id --expression '== "HeaFdiyIJe"'
```

Note the use of double-quotes above. That's because strings are being compared. If strings were not used, it would give:

```
check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path id --expression '== HeaFdiyIJe'
CheckHttp CRITICAL - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at id with value HeaFdiyIJe does not match expression "== HeaFdiyIJe"
```

More examples using other operators (note the use of double-quotes for strings):

```
check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path id --expression '<= "IeaFdiyIJe"'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at id with value HeaFdiyIJe and expression "<= "IeaFdiyIJe"" yields true

check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path id --expression '>= "HeaFdiyIJd"'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at id with value HeaFdiyIJe and expression ">= "HeaFdiyIJd"" yields true

check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path id --expression '!= "notequal"'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at id with value HeaFdiyIJe and expression "!= "notequal"" yields true
```

And examples using number comparisons (double-quotes not used)

```
check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path status --expression '== 200'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at status with value 200 and expression "== 200" yields true

check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path status --expression '>= 200'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at status with value 200 and expression ">= 200" yields true

check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe  --format json --path status --expression '< 400'
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at status with value 200 and expression "< 400" yields true
```

Finally, an example using string comparison especially for Windows users at the Command Prompt shell. Notice the `--expression` option is contained in double-quotes and the double-quotes inside the option are given by using two double-quotes.

```
check_http --url https://icanhazdadjoke.com/j/HeaFdiyIJe --format json --path id --expression "== ""HeaFdiyIJe"""
CheckHttp OK - Url https://icanhazdadjoke.com/j/HeaFdiyIJe responded with 200. The value found at id with value HeaFdiyIJe and expression "== "HeaFdiyIJe"" yields true
```

This PR also contains a good amount of refactoring. Too much logic has been getting piled into the mainline `CheckHTTP()` function so it's time to refactor into smaller functions containing easily testable logic. I've done this and added unit tests to support these new functions. While more improvements could be made, the main `CheckHTTP()` function is now much easier to follow. I've also included explicit error checking for the `--format` and better error output when the `--path` is not found.

Resolves #155