### PR TITLE
Update check_service help

### DIFF
--- a/cmd/check_service/cmd/root.go
+++ b/cmd/check_service/cmd/root.go
@@ -21,7 +21,7 @@ func Execute() {
 
 	var rootCmd = &cobra.Command{
 		Use:   "check_service",
-		Short: "Determine if a service is running.",
+		Short: "Determine the status of a service.",
 		Long: `Perform various checks for a service. These checks depend on the options
 given and the --name (-n) option is always required.` + getHelpOsConstrained(),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Update the in-program help for `check_service` to reflect that it does more than just check if a service is running. Resolves #128.