### PR TITLE
Convert option examples from single to double dashes

### DIFF
--- a/cmd/check_cpu/README.md
+++ b/cmd/check_cpu/README.md
@@ -1,9 +1,9 @@
 # CPU Check
-The CPU check retrieves the CPU load as a percentage and if it is over `-critical` (default 95%), will output a `CRITICAL` response. If a `CRITICAL` response is not output, it compares it to `-warning` (default 85%) and if over, will output a `WARNING` response. Anything else will output an `OK` response.
+The CPU check retrieves the CPU load as a percentage and if it is over `--critical` (default 95%), will output a `CRITICAL` response. If a `CRITICAL` response is not output, it compares it to `--warning` (default 85%) and if over, will output a `WARNING` response. Anything else will output an `OK` response.
 
-The `-critical` and `-warning` flags can be set on the command line as desired.
+The `--critical` and `--warning` flags can be set on the command line as desired.
 
-A `-metric_name` flag can also be specified. This string is output in the response message in a Nagios format and is suitable for machine parsing. The default is `pct_processor_time`.
+A `--metric_name` flag can also be specified. This string is output in the response message in a Nagios format and is suitable for machine parsing. The default is `pct_processor_time`.
 
 ## Examples
 Default check values
@@ -13,10 +13,10 @@ check_cpu
 
 Warning level set to 70%
 ```
-check_cpu -warning 70
+check_cpu --warning 70
 ```
 
 Override the metric name
 ```
-check_cpu -metric_name cpu_percentage
+check_cpu --metric_name cpu_percentage
 ```

--- a/cmd/check_user_group/README.md
+++ b/cmd/check_user_group/README.md
@@ -5,19 +5,23 @@ The user and group check (`check_user_group`) will check for the existence of a 
 All features of this check are applicable to both Linux and Windows.
 
 ## Check for a User
-Use the `-user` flag to check for the existence of a user. It is the only command like flag required for this check.
+Use the `--user` flag to check for the existence of a user. It is the only command like flag required for this check.
+
 ```
-check_user_group -user nobody
-````
+check_user_group --user nobody
+```
 
 ## Check for a Group
-Use the `-group` flag to check for the existence of a group. It is the only command line flag required for this check.
+
+Use the `--group` flag to check for the existence of a group. It is the only command line flag required for this check.
+
 ```
-check_user_group -group sudo
+check_user_group --group sudo
 ```
 
 ## Check for a User Belonging to a Group
-Use both the `-user` and `-group` flags to check if a user exists and verify the user is in a group.
+Use both the `--user` and `--group` flags to check if a user exists and verify the user is in a group.
+
 ```
-check_user_group -user adm -group syslog 
+check_user_group --user adm --group syslog 
 ```


### PR DESCRIPTION
This PR resolves #156 (single dashes in the `cpu_check` README) as well as the same problem in `check_user_group`.
