### PR TITLE
Add and use common resultMessage()

### DIFF
--- a/lib/app/nagiosfoundation/check_cpu.go
+++ b/lib/app/nagiosfoundation/check_cpu.go
@@ -4,7 +4,6 @@ package nagiosfoundation
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/ncr-devops-platform/nagiosfoundation/lib/pkg/cpu"
 	"github.com/ncr-devops-platform/nagiosfoundation/lib/pkg/nagiosformatters"
@@ -32,7 +31,7 @@ func CheckCPUWithHandler(warning, critical int, metricName string, cpuHandler fu
 	if err == nil {
 		msg, retcode = nagiosformatters.GreaterFormatNagiosCheck(checkName, value, float64(warning), float64(critical), metricName)
 	} else {
-		msg = fmt.Sprintf("%s CRITICAL - %s", checkName, err)
+		msg, _ = resultMessage(checkName, statusTextCritical, err.Error())
 		retcode = 2
 	}
 

--- a/lib/app/nagiosfoundation/check_file_exists.go
+++ b/lib/app/nagiosfoundation/check_file_exists.go
@@ -8,10 +8,6 @@ import (
 
 // CheckFileExists tests the assertion that one or more files matching specified pattern should or should not exist.
 func CheckFileExists(pattern string, negate bool) (string, int) {
-	const ok = "OK"
-	const critical = "CRITICAL"
-	const unknown = "UNKNOWN"
-
 	var msg string
 	var retCode int
 	var checkStateText, msgString string
@@ -20,7 +16,7 @@ func CheckFileExists(pattern string, negate bool) (string, int) {
 
 	switch {
 	case err != nil:
-		checkStateText = unknown
+		checkStateText = statusTextUnknown
 		msgString = fmt.Sprintf("Error matching pattern %s: %s", pattern, err)
 		retCode = 3
 	default:
@@ -29,18 +25,17 @@ func CheckFileExists(pattern string, negate bool) (string, int) {
 		switch {
 		case (matchCount == 0 && negate == false) ||
 			(matchCount > 0 && negate == true):
-			checkStateText = critical
+			checkStateText = statusTextCritical
 			retCode = 2
 		case (matchCount == 0 && negate == true) ||
 			(matchCount > 0 && negate == false):
-			checkStateText = ok
+			checkStateText = statusTextOK
 			retCode = 0
 		}
 
 		msgString = fmt.Sprintf("%s files matched pattern %s", strconv.Itoa(len(matches)), pattern)
 	}
 
-	msg = fmt.Sprintf("%s: %s", checkStateText, msgString)
-
+	msg, _ = resultMessage("CheckFileExists", checkStateText, msgString)
 	return msg, retCode
 }

--- a/lib/app/nagiosfoundation/check_file_exists_test.go
+++ b/lib/app/nagiosfoundation/check_file_exists_test.go
@@ -23,9 +23,6 @@ func TestCheckFileExists(t *testing.T) {
 	var code int
 	const validTestFile = "validtestfile"
 	const invalidTestFile = "invalidtestfile"
-	const ok = "OK:"
-	const critical = "CRITICAL:"
-	const unknown = "UNKNOWN:"
 
 	type testItem struct {
 		description  string
@@ -41,35 +38,35 @@ func TestCheckFileExists(t *testing.T) {
 			file:         "[]a",
 			inverted:     false,
 			expectedCode: 3,
-			expectedMsg:  unknown,
+			expectedMsg:  statusTextUnknown,
 		},
 		{
 			description:  "File does not exist, not inverted",
 			file:         invalidTestFile,
 			inverted:     false,
 			expectedCode: 2,
-			expectedMsg:  critical,
+			expectedMsg:  statusTextCritical,
 		},
 		{
 			description:  "File does not exist, inverted",
 			file:         invalidTestFile,
 			inverted:     true,
 			expectedCode: 0,
-			expectedMsg:  ok,
+			expectedMsg:  statusTextOK,
 		},
 		{
 			description:  "File exists, not inverted",
 			file:         validTestFile,
 			inverted:     false,
 			expectedCode: 0,
-			expectedMsg:  ok,
+			expectedMsg:  statusTextOK,
 		},
 		{
 			description:  "File exists, inverted",
 			file:         validTestFile,
 			inverted:     true,
 			expectedCode: 2,
-			expectedMsg:  critical,
+			expectedMsg:  statusTextCritical,
 		},
 	}
 

--- a/lib/app/nagiosfoundation/check_process.go
+++ b/lib/app/nagiosfoundation/check_process.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+const checkProcessName = "CheckProcess"
+
 func getPidNameWithHandler(readFile func(string) ([]byte, error), pid int) (string, error) {
 	procFile := fmt.Sprintf("/proc/%d/stat", pid)
 	procDataBytes, err := readFile(procFile)
@@ -145,10 +147,10 @@ func checkRunning(processCheck ProcessCheck, invert bool) (string, int) {
 	result := processCheck.IsProcessRunning()
 	if result != invert {
 		retcode = 0
-		responseStateText = "OK"
+		responseStateText = statusTextOK
 	} else {
 		retcode = 2
-		responseStateText = "CRITICAL"
+		responseStateText = statusTextCritical
 	}
 
 	if result == true {
@@ -157,7 +159,8 @@ func checkRunning(processCheck ProcessCheck, invert bool) (string, int) {
 		checkInfo = "not "
 	}
 
-	msg = fmt.Sprintf("CheckProcess %s - Process %s is %srunning", responseStateText, processCheck.ProcessName, checkInfo)
+	msg, _ = resultMessage(checkProcessName, responseStateText,
+		fmt.Sprintf("Process %s is %srunning", processCheck.ProcessName, checkInfo))
 
 	return msg, retcode
 }
@@ -208,7 +211,7 @@ func checkProcessCmd(name string, checkType string, checkProcess func(string, st
 	}
 
 	if invalidParametersMsg != "" {
-		msg = fmt.Sprintf("CheckProcess CRITICAL - %s", invalidParametersMsg)
+		msg, _ = resultMessage(checkProcessName, statusTextCritical, invalidParametersMsg)
 		retcode = 2
 	} else {
 		msg, retcode = checkProcess(name, checkType, processService)

--- a/lib/app/nagiosfoundation/resultmessage.go
+++ b/lib/app/nagiosfoundation/resultmessage.go
@@ -1,0 +1,60 @@
+package nagiosfoundation
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	statusTextOK       = "OK"
+	statusTextWarning  = "WARNING"
+	statusTextCritical = "CRITICAL"
+	statusTextUnknown  = "UNKNOWN"
+)
+
+var errResultMsgNotEnoughArgs = errors.New("Not enough arguments")
+var errResultMsgTooManyArgs = errors.New("Too many arguments")
+var errResultMsgInvalidStatus = errors.New("Invalid status text")
+
+func resultMessage(s ...string) (string, error) {
+	// s[0] - check name
+	// s[1] - status text
+	// s[2] - result description
+	// s[3] - nagios output
+
+	const (
+		checkNameOffset = iota
+		statusTextOffset
+		resultDescOffset
+		nagiosOutputOffset
+	)
+
+	var msg string
+	var err error
+
+	argCount := len(s)
+
+	if argCount < 2 {
+		err = errResultMsgNotEnoughArgs
+	} else if argCount > 4 {
+		err = errResultMsgTooManyArgs
+	} else if s[statusTextOffset] != statusTextOK && s[statusTextOffset] != statusTextWarning &&
+		s[statusTextOffset] != statusTextCritical && s[statusTextOffset] != statusTextUnknown {
+		err = errResultMsgInvalidStatus
+	} else {
+		// "CheckName OK"
+		msg = fmt.Sprintf("%s %s", s[checkNameOffset], s[statusTextOffset])
+
+		// "CheckName OK - Description of result"
+		if argCount > resultDescOffset && len(s[resultDescOffset]) > 0 {
+			msg += fmt.Sprintf(" - %s", s[resultDescOffset])
+		}
+
+		// "CheckName OK - Description of result | nagios output"
+		if argCount > nagiosOutputOffset && len(s[nagiosOutputOffset]) > 0 {
+			msg += fmt.Sprintf(" | %s", s[nagiosOutputOffset])
+		}
+	}
+
+	return msg, err
+}

--- a/lib/app/nagiosfoundation/resutmessage_test.go
+++ b/lib/app/nagiosfoundation/resutmessage_test.go
@@ -1,0 +1,75 @@
+package nagiosfoundation
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestResultMessage(t *testing.T) {
+	checkName := "TestName"
+	statusText := "OK"
+	description := "Description"
+	nagiosOutput := "nagios output"
+
+	// All parameters populated, valid result
+	expectedValue := fmt.Sprintf("%s %s - %s | %s", checkName, statusText, description, nagiosOutput)
+	actualValue, err := resultMessage(checkName, statusText, description, nagiosOutput)
+	if err != nil {
+		t.Error("resultMessage() with all parameters should have returned valid result. Err:", err)
+	}
+	if actualValue != expectedValue {
+		t.Errorf("resultMessage() with all parameters did not return expected message. Expected: %s, Actual: %s", expectedValue, actualValue)
+	}
+
+	// Nagios output not populated, valid result
+	expectedValue = fmt.Sprintf("%s %s - %s", checkName, statusText, description)
+	actualValue, err = resultMessage(checkName, statusText, description)
+	if err != nil {
+		t.Error("resultMessage() with 3 parameters should have returned valid result. Err:", err)
+	}
+	if actualValue != expectedValue {
+		t.Errorf("resultMessage() with 3 parameters did not return expected message. Expected: %s, Actual: %s", expectedValue, actualValue)
+	}
+
+	// Only required parameters populated, valid result
+	expectedValue = fmt.Sprintf("%s %s", checkName, statusText)
+	actualValue, err = resultMessage(checkName, statusText)
+	if err != nil {
+		t.Error("resultMessage() with all parameters should have returned valid result. Err:", err)
+	}
+	if actualValue != expectedValue {
+		t.Errorf("resultMessage() with all parameters did not return expected message. Expected: %s, Actual: %s", expectedValue, actualValue)
+	}
+
+	// Invalid status text
+	_, err = resultMessage("TestName", "INVALIDTEXTRESULT")
+	if err != errResultMsgInvalidStatus {
+		t.Error("resultMessage() with invalid status text should have returned errResultMsgInvalidStatus")
+	}
+
+	// Only one parameter
+	_, err = resultMessage("TestName")
+	if err != errResultMsgNotEnoughArgs {
+		t.Error("resultMessage() with one parameter should have returned errResultMsgNotEnoughArgs")
+	}
+
+	// No parameters
+	_, err = resultMessage()
+	if err != errResultMsgNotEnoughArgs {
+		t.Error("resultMessage() with no parameters should have returned errResultMsgNotEnoughArgs")
+	}
+
+	// Too many parameters
+	_, err = resultMessage("", "", "", "", "")
+	if err != errResultMsgTooManyArgs {
+		t.Error("resultMessage() with five parameters should have returned errResultMsgTooManyArgs")
+	}
+
+	// Test remaining status text values
+	for _, statusText := range []string{statusTextCritical, statusTextWarning, statusTextUnknown} {
+		_, err = resultMessage("TestName", statusText)
+		if err != nil {
+			t.Errorf("resultMessage() with valid status text of %s failed", statusText)
+		}
+	}
+}


### PR DESCRIPTION
When I approved and merged PR #149 for `check_file_exists` I missed that the result message is in a different format than the other checks. To help with future reviews and contributors, I created a `resultMessage()` function that outputs a string in the standard message format. Reviewers just need to make sure `resultMessage()` is used and contributors don't need to check how the output message should be formatted. The contributor simply needs to use `resultMessage()` and the rest is taken care of for them. I've also added standard `const`s for the `OK`, `WARNING`, `CRITICAL` and `UNKNOWN` status in an attempt to standardize them.

```
const (
	statusTextOK       = "OK"
	statusTextWarning  = "WARNING"
	statusTextCritical = "CRITICAL"
	statusTextUnknown  = "UNKNOWN"
)
```

The `resultMessage()` function checks these status text strings and fails if it doesn't match one of them. It can take a variable number of arguments, from 2 to 4 depending on what the caller wishes to provide. Examples are:

```
resultMessage("CheckName", "OK")
CheckName OK

resultMessage("CheckName", "OK", "Description")
CheckName OK - Description

resultMessage("CheckName", "OK", "Description", "Nagios Output")
CheckName OK - Description | Nagis Output
```

An error is returned on not enough arguments, two many arguments, or invalid status text

For this PR I've modified the following checks to use `resultMessage()`

- `check_file_exists`
- `check_process`
- `check_service`
- `check_user_group`

Because of outstanding pull requests, I'm delaying modifying `check_http` and `check_memory` until those PRs are merged.
