### PR TITLE
user/group check exit with proper critical code

### DIFF
--- a/lib/app/nagiosfoundation/check_user_group.go
+++ b/lib/app/nagiosfoundation/check_user_group.go
@@ -69,7 +69,7 @@ type UserGroupCheck struct {
 // operating system.
 //
 // Returns a string containing plaintext result and an integer
-// with the return code. 0 indicates the user exists, 3 indicates
+// with the return code. 0 indicates the user exists, 2 indicates
 // the user does not exist.
 func (ugc UserGroupCheck) CheckUser() (string, int) {
 	var retCode int
@@ -80,11 +80,11 @@ func (ugc UserGroupCheck) CheckUser() (string, int) {
 	if err == nil {
 		formatString = "User %s exists"
 		status = statusTextOK
-		retCode = 0
+		retCode = statusCodeOK
 	} else {
 		formatString = "User %s does not exist"
 		status = statusTextCritical
-		retCode = 3
+		retCode = statusCodeCritical
 	}
 
 	msg, _ := resultMessage(checkUserName, status, fmt.Sprintf(formatString, ugc.UserName))
@@ -95,7 +95,7 @@ func (ugc UserGroupCheck) CheckUser() (string, int) {
 // operating system.
 //
 // Returns a string containing plaintext result and an integer
-// with the return code. 0 indicates the group exists, 3 indicates
+// with the return code. 0 indicates the group exists, 2 indicates
 // the group does not exist.
 func (ugc UserGroupCheck) CheckGroup() (string, int) {
 	var retCode int
@@ -106,11 +106,11 @@ func (ugc UserGroupCheck) CheckGroup() (string, int) {
 	if err == nil {
 		formatString = "Group %s exists"
 		status = statusTextOK
-		retCode = 0
+		retCode = statusCodeOK
 	} else {
 		formatString = "Group %s does not exist"
 		status = statusTextCritical
-		retCode = 3
+		retCode = statusCodeCritical
 	}
 
 	msg, _ := resultMessage(checkGroupName, status, fmt.Sprintf(formatString, ugc.GroupName))
@@ -122,10 +122,10 @@ func (ugc UserGroupCheck) CheckGroup() (string, int) {
 //
 // Returns a string containing plaintext result and an integer
 // with the return code. 0 indicates the user exists and is in
-// the group, 3 indicates otherwise.
+// the group, 2 indicates otherwise.
 func (ugc UserGroupCheck) CheckUserGroup() (string, int) {
 	var msg, status string
-	retcode := 3
+	retcode := statusCodeCritical
 
 	userInfo, err := ugc.Service.Lookup(ugc.UserName)
 	if err != nil {
@@ -147,7 +147,7 @@ func (ugc UserGroupCheck) CheckUserGroup() (string, int) {
 					msg = fmt.Sprintf("User %s exists and is in Group %s",
 						ugc.UserName, ugc.GroupName)
 					status = statusTextOK
-					retcode = 0
+					retcode = statusCodeOK
 				}
 			}
 		}

--- a/lib/app/nagiosfoundation/check_user_group_test.go
+++ b/lib/app/nagiosfoundation/check_user_group_test.go
@@ -60,7 +60,7 @@ func TestCheckUser(t *testing.T) {
 		UserName:  goodUserGroupString,
 		GroupName: "",
 		Service:   new(userGroupTestHandler),
-	}).CheckUser(); retval != 0 {
+	}).CheckUser(); retval != statusCodeOK {
 		t.Error("CheckUser() with good user failed")
 	}
 
@@ -68,7 +68,7 @@ func TestCheckUser(t *testing.T) {
 		UserName:  badUserGroupString,
 		GroupName: "",
 		Service:   new(userGroupTestHandler),
-	}).CheckUser(); retval != 3 {
+	}).CheckUser(); retval != statusCodeCritical {
 		t.Error("CheckUser() with bad user failed")
 	}
 }
@@ -81,7 +81,7 @@ func TestCheckGroup(t *testing.T) {
 		UserName:  "",
 		GroupName: goodUserGroupString,
 		Service:   handler,
-	}).CheckGroup(); retval != 0 {
+	}).CheckGroup(); retval != statusCodeOK {
 		t.Error("CheckGroup() with good group failed")
 	}
 
@@ -89,7 +89,7 @@ func TestCheckGroup(t *testing.T) {
 		UserName:  "",
 		GroupName: badUserGroupString,
 		Service:   handler,
-	}).CheckGroup(); retval != 3 {
+	}).CheckGroup(); retval != statusCodeCritical {
 		t.Error("CheckGroup() with bad group failed")
 	}
 }
@@ -102,7 +102,7 @@ func TestCheckUserGroup(t *testing.T) {
 		UserName:  goodUserGroupString,
 		GroupName: goodUserGroupString,
 		Service:   handler,
-	}).CheckUserGroup(); retval != 0 {
+	}).CheckUserGroup(); retval != statusCodeOK {
 		t.Error("CheckGroup() with good user and good group failed")
 	}
 
@@ -110,7 +110,7 @@ func TestCheckUserGroup(t *testing.T) {
 		UserName:  errorUserGroupString,
 		GroupName: goodUserGroupString,
 		Service:   handler,
-	}).CheckUserGroup(); retval != 3 {
+	}).CheckUserGroup(); retval != statusCodeCritical {
 		t.Error("CheckGroup() with GroupIds() returning error failed")
 	}
 
@@ -118,7 +118,7 @@ func TestCheckUserGroup(t *testing.T) {
 		UserName:  goodUserGroupString,
 		GroupName: badUserGroupString,
 		Service:   handler,
-	}).CheckUserGroup(); retval != 3 {
+	}).CheckUserGroup(); retval != statusCodeCritical {
 		t.Error("CheckGroup() with good user and bad group failed")
 	}
 
@@ -126,7 +126,7 @@ func TestCheckUserGroup(t *testing.T) {
 		UserName:  badUserGroupString,
 		GroupName: badUserGroupString,
 		Service:   handler,
-	}).CheckUserGroup(); retval != 3 {
+	}).CheckUserGroup(); retval != statusCodeCritical {
 		t.Error("CheckGroup() with bad user and bad group failed")
 	}
 
@@ -134,7 +134,7 @@ func TestCheckUserGroup(t *testing.T) {
 		UserName:  badUserGroupString,
 		GroupName: goodUserGroupString,
 		Service:   handler,
-	}).CheckUserGroup(); retval != 3 {
+	}).CheckUserGroup(); retval != statusCodeCritical {
 		t.Error("CheckGroup() with bad user and good group failed")
 	}
 }
@@ -143,17 +143,17 @@ func TestCheckUserGroupWithFlags(t *testing.T) {
 	handler := new(userGroupTestHandler)
 
 	_, err := CheckUserGroupWithHandler(goodUserGroupString, "", handler)
-	if err != 0 {
-		t.Error("CheckUserGroup with -user flag failed")
+	if err != statusCodeOK {
+		t.Error("CheckUserGroup with --user flag failed")
 	}
 
 	_, err = CheckUserGroupWithHandler("", goodUserGroupString, handler)
-	if err != 0 {
-		t.Error("CheckUserGroup with -group flag failed")
+	if err != statusCodeOK {
+		t.Error("CheckUserGroup with --group flag failed")
 	}
 
 	_, err = CheckUserGroupWithHandler(goodUserGroupString, goodUserGroupString, handler)
-	if err != 0 {
-		t.Error("CheckUserGroup with -user and -group flags failed")
+	if err != statusCodeOK {
+		t.Error("CheckUserGroup with --user and --group flags failed")
 	}
 }

--- a/lib/app/nagiosfoundation/resultmessage.go
+++ b/lib/app/nagiosfoundation/resultmessage.go
@@ -12,6 +12,13 @@ const (
 	statusTextUnknown  = "UNKNOWN"
 )
 
+const (
+	statusCodeOK = iota
+	statusCodeWarning
+	statusCodeCritical
+	statusCodeUnknown
+)
+
 var errResultMsgNotEnoughArgs = errors.New("Not enough arguments")
 var errResultMsgTooManyArgs = errors.New("Too many arguments")
 var errResultMsgInvalidStatus = errors.New("Invalid status text")


### PR DESCRIPTION
Resolves #167 

Also sets the framework for replacing magic numbers in exit codes for all the checks using `const`s.

```
const (
	statusCodeOK = iota
	statusCodeWarning
	statusCodeCritical
	statusCodeUnknown
)
```