### PR TITLE
Add configuration needed to include this project on Bonsai

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -1,0 +1,34 @@
+---
+description: "#{repo}"
+builds:
+- platform: "linux"
+  arch: "amd64"
+  asset_filename: "#{repo}-linux-amd64-#{version}.tgz"
+  sha_filename: "#{repo}-linux-amd64-#{version}-sha512.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == 'amd64'"
+
+- platform: "linux"
+  arch: "386"
+  asset_filename: "#{repo}-linux-386-#{version}.tgz"
+  sha_filename: "#{repo}-linux-386-#{version}-sha512.txt"
+  filter:
+  -  "entity.system.os == 'linux'"
+  -  "entity.system.arch == '386'"
+
+- platform: "Windows"
+  arch: "amd64"
+  asset_filename: "#{repo}-windows-amd64-#{version}.tgz"
+  sha_filename: "#{repo}-windows-amd64-#{version}-sha512.txt"
+  filter:
+  -  "entity.system.os == 'windows'"
+  -  "entity.system.arch == 'amd64'"
+
+- platform: "Windows"
+  arch: "amd64"
+  asset_filename: "#{repo}-windows-386-#{version}.tgz"
+  sha_filename: "#{repo}-windows-386-#{version}-sha512.txt"
+  filter:
+  -  "entity.system.os == 'windows'"
+  -  "entity.system.arch == '386'"

--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -26,7 +26,7 @@ builds:
   -  "entity.system.arch == 'amd64'"
 
 - platform: "Windows"
-  arch: "amd64"
+  arch: "386"
   asset_filename: "#{repo}-windows-386-#{version}.tgz"
   sha_filename: "#{repo}-windows-386-#{version}-sha512.txt"
   filter:


### PR DESCRIPTION
We'd love to add this project to [Bonsai](https://bonsai.sensu.io), the Sensu Asset Index. Because godel already builds tgz and checksums, I believe the file added here is the only change needed in the repository.

Once this change is accepted, one of the maintainers should be able to sign into Bonsai via GitHub account and add the repository via https://bonsai.sensu.io/new.